### PR TITLE
Add support for HTTP basic auth args

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -99,6 +99,15 @@ pub struct Args {
     )]
     pub exclude: Regex,
 
+    /// HTTP basic authentication credentials
+    #[structopt(
+        short,
+        long,
+        use_delimiter = true,
+        help = "HTTP basic authentication credentials, comma separated as \"username,password,host\""
+    )]
+    pub auth: Vec<String>,
+
     /// Decides if we should bail out on download error (like, too many redirects)
     #[structopt(short, long, help = "Flag to enable or disable exit on error")]
     pub continue_on_error: bool,

--- a/src/args.rs
+++ b/src/args.rs
@@ -104,7 +104,8 @@ pub struct Args {
         short,
         long,
         use_delimiter = true,
-        help = "HTTP basic authentication credentials, comma separated as \"username,password,host\""
+        value_delimiter = " ",
+        help = "HTTP basic authentication credentials space-separated as \"username password host\". Can be repeated for multiple credentials"
     )]
     pub auth: Vec<String>,
 

--- a/src/args.rs
+++ b/src/args.rs
@@ -105,7 +105,7 @@ pub struct Args {
         long,
         use_delimiter = true,
         value_delimiter = " ",
-        help = "HTTP basic authentication credentials space-separated as \"username password host\". Can be repeated for multiple credentials"
+        help = "HTTP basic authentication credentials space-separated as \"username password host\". Can be repeated for multiple credentials as \"u1 p1 h1 u2 p2 h2\""
     )]
     pub auth: Vec<String>,
 

--- a/src/downloader.rs
+++ b/src/downloader.rs
@@ -1,4 +1,5 @@
 use super::response::{Response, ResponseData};
+use std::collections::HashMap;
 use url::Url;
 
 use crate::warn;
@@ -7,11 +8,39 @@ use crate::warn;
 pub struct Downloader {
     client: reqwest::blocking::Client,
     tries: usize,
+    auth_map: HashMap<Option<String>, (String, Option<String>)>,
+}
+
+///Parse HTTP authentication credentials from string iterable
+fn parse_auth(auth: &[String]) -> Option<(String, Option<String>, Option<String>)> {
+    // Convert any empty strings to None
+    let auth: Vec<Option<String>> = auth
+        .iter()
+        .map(|s| match s.as_ref() {
+            "" => None,
+            s => Some(s.to_string()),
+        })
+        .collect();
+    match auth.as_slice() {
+        [] => None,
+        [None, ..] => None, // Empty username should be considered no-op
+        [Some(username)] => Some((username.to_string(), None, None)),
+        [Some(username), password] => Some((username.to_string(), password.clone(), None)),
+        [Some(username), password, host, ..] => {
+            Some((username.to_string(), password.clone(), host.clone()))
+        }
+    }
 }
 
 impl Downloader {
     /// Create a new Downloader
-    pub fn new(tries: usize, user_agent: &str) -> Downloader {
+    pub fn new(tries: usize, user_agent: &str, auth: &[String]) -> Downloader {
+        // Create a mapping of hosts to username, password tuples for authentication
+        let mut auth_map = HashMap::new();
+        if let Some((username, password, host)) = parse_auth(auth) {
+            auth_map.insert(host, (username, password));
+        }
+
         Downloader {
             client: reqwest::blocking::ClientBuilder::new()
                 .cookie_store(true)
@@ -19,6 +48,7 @@ impl Downloader {
                 .build()
                 .unwrap(),
             tries,
+            auth_map,
         }
     }
 
@@ -39,9 +69,22 @@ impl Downloader {
         }
     }
 
+    /// Load HTTP auth credentials in a username, password tuple based on the host string
+    fn get_auth(&self, url: &Url) -> Option<&(String, Option<String>)> {
+        match self.auth_map.get(&url.host_str().map(String::from)) {
+            Some(auth) => Some(auth),
+            None => self.auth_map.get(&None),
+        }
+    }
+
     ///Download the content at this url
     fn make_request(&self, url: &Url) -> Result<Response, reqwest::Error> {
-        match self.client.get(url.clone()).send() {
+        let req = self.client.get(url.clone());
+        let req = match self.get_auth(url) {
+            Some((username, password)) => req.basic_auth(username, password.clone()),
+            None => req,
+        };
+        match req.send() {
             Ok(mut data) => {
                 let data_type = match data.headers().get("content-type") {
                     Some(data_type) => data_type.to_str().unwrap(),
@@ -93,9 +136,31 @@ mod tests {
     #[test]
     fn test_download_url() {
         let url: Url = Url::parse("https://lwn.net").unwrap();
-        match Downloader::new(1, "suckit").get(&url) {
+        match Downloader::new(1, "suckit", &[]).get(&url) {
             Err(e) => assert!(false, "Fail to download lwn.net: {:?}", e),
             _ => {}
         }
+    }
+
+    #[test]
+    fn test_parse_auth() {
+        assert_eq!(parse_auth(&["".to_string(), "pw".to_string()]), None);
+        assert_eq!(
+            parse_auth(&["username".to_string()]),
+            Some(("username".to_string(), None, None))
+        );
+        assert_eq!(
+            parse_auth(&[
+                "un".to_string(),
+                "pw".to_string(),
+                "h".to_string(),
+                "t".to_string()
+            ]),
+            Some((
+                "un".to_string(),
+                Some("pw".to_string()),
+                Some("h".to_string())
+            ))
+        )
     }
 }

--- a/src/downloader.rs
+++ b/src/downloader.rs
@@ -37,8 +37,11 @@ impl Downloader {
     pub fn new(tries: usize, user_agent: &str, auth: &[String]) -> Downloader {
         // Create a mapping of hosts to username, password tuples for authentication
         let mut auth_map = HashMap::new();
-        if let Some((username, password, host)) = parse_auth(auth) {
-            auth_map.insert(host, (username, password));
+        // Iterate over the auth string in chunks of 3 items each for (username, password, host)
+        for auth_chunk in auth.chunks(3) {
+            if let Some((username, password, host)) = parse_auth(auth_chunk) {
+                auth_map.insert(host, (username, password));
+            }
         }
 
         Downloader {

--- a/src/downloader.rs
+++ b/src/downloader.rs
@@ -4,6 +4,8 @@ use url::Url;
 
 use crate::warn;
 
+const AUTH_CHUNK_SIZE: usize = 3;
+
 ///A Downloader to download web content
 pub struct Downloader {
     client: reqwest::blocking::Client,
@@ -50,7 +52,7 @@ impl Downloader {
         // Create a mapping of hosts to username, password tuples for authentication
         let mut auth_map = HashMap::new();
         // Iterate over the auth string in chunks of 3 items each for (username, password, host)
-        for auth_chunk in auth.chunks(3) {
+        for auth_chunk in auth.chunks(AUTH_CHUNK_SIZE) {
             // Throwing the error with panic! for now if parsing fails
             let (username, password, host) = parse_auth(auth_chunk, origin).unwrap();
             auth_map.insert(host, (username, password));

--- a/src/downloader.rs
+++ b/src/downloader.rs
@@ -8,11 +8,11 @@ use crate::warn;
 pub struct Downloader {
     client: reqwest::blocking::Client,
     tries: usize,
-    auth_map: HashMap<Option<String>, (String, Option<String>)>,
+    auth_map: HashMap<String, (String, Option<String>)>,
 }
 
-///Parse HTTP authentication credentials from string iterable
-fn parse_auth(auth: &[String]) -> Option<(String, Option<String>, Option<String>)> {
+/// Parse HTTP authentication credentials from string iterable
+fn parse_auth(auth: &[String], origin: &Url) -> Result<(String, Option<String>, String), String> {
     // Convert any empty strings to None
     let auth: Vec<Option<String>> = auth
         .iter()
@@ -21,27 +21,39 @@ fn parse_auth(auth: &[String]) -> Option<(String, Option<String>, Option<String>
             s => Some(s.to_string()),
         })
         .collect();
-    match auth.as_slice() {
-        [] => None,
-        [None, ..] => None, // Empty username should be considered no-op
-        [Some(username)] => Some((username.to_string(), None, None)),
-        [Some(username), password] => Some((username.to_string(), password.clone(), None)),
-        [Some(username), password, host, ..] => {
-            Some((username.to_string(), password.clone(), host.clone()))
+
+    // Match on auth values and origin host, defaulting to the origin host if host not provided
+    match (auth.as_slice(), origin.host_str()) {
+        ([Some(username)], Some(origin_host)) => {
+            Ok((username.to_string(), None, origin_host.to_string()))
         }
+        ([Some(username), password], Some(origin_host)) => Ok((
+            username.to_string(),
+            password.clone(),
+            origin_host.to_string(),
+        )),
+        ([Some(username), password, None, ..], Some(origin_host)) => Ok((
+            username.to_string(),
+            password.clone(),
+            origin_host.to_string(),
+        )),
+        ([Some(username), password, Some(host), ..], _) => {
+            Ok((username.to_string(), password.clone(), host.to_string()))
+        }
+        _ => Err("Invalid arguments supplied to auth".to_string()),
     }
 }
 
 impl Downloader {
     /// Create a new Downloader
-    pub fn new(tries: usize, user_agent: &str, auth: &[String]) -> Downloader {
+    pub fn new(tries: usize, user_agent: &str, auth: &[String], origin: &Url) -> Downloader {
         // Create a mapping of hosts to username, password tuples for authentication
         let mut auth_map = HashMap::new();
         // Iterate over the auth string in chunks of 3 items each for (username, password, host)
         for auth_chunk in auth.chunks(3) {
-            if let Some((username, password, host)) = parse_auth(auth_chunk) {
-                auth_map.insert(host, (username, password));
-            }
+            // Throwing the error with panic! for now if parsing fails
+            let (username, password, host) = parse_auth(auth_chunk, origin).unwrap();
+            auth_map.insert(host, (username, password));
         }
 
         Downloader {
@@ -74,9 +86,10 @@ impl Downloader {
 
     /// Load HTTP auth credentials in a username, password tuple based on the host string
     fn get_auth(&self, url: &Url) -> Option<&(String, Option<String>)> {
-        match self.auth_map.get(&url.host_str().map(String::from)) {
-            Some(auth) => Some(auth),
-            None => self.auth_map.get(&None),
+        if let Some(host) = url.host_str() {
+            self.auth_map.get(&host.to_string())
+        } else {
+            None
         }
     }
 
@@ -139,7 +152,7 @@ mod tests {
     #[test]
     fn test_download_url() {
         let url: Url = Url::parse("https://lwn.net").unwrap();
-        match Downloader::new(1, "suckit", &[]).get(&url) {
+        match Downloader::new(1, "suckit", &[], &url).get(&url) {
             Err(e) => assert!(false, "Fail to download lwn.net: {:?}", e),
             _ => {}
         }
@@ -147,23 +160,31 @@ mod tests {
 
     #[test]
     fn test_parse_auth() {
-        assert_eq!(parse_auth(&["".to_string(), "pw".to_string()]), None);
         assert_eq!(
-            parse_auth(&["username".to_string()]),
-            Some(("username".to_string(), None, None))
+            parse_auth(
+                &["".to_string(), "pw".to_string()],
+                &Url::parse("https://example.com/").unwrap()
+            ),
+            Err("Invalid arguments supplied to auth".to_string())
         );
         assert_eq!(
-            parse_auth(&[
-                "un".to_string(),
-                "pw".to_string(),
-                "h".to_string(),
-                "t".to_string()
-            ]),
-            Some((
-                "un".to_string(),
-                Some("pw".to_string()),
-                Some("h".to_string())
-            ))
+            parse_auth(
+                &["username".to_string()],
+                &Url::parse("https://example.com/").unwrap()
+            ),
+            Ok(("username".to_string(), None, "example.com".to_string()))
+        );
+        assert_eq!(
+            parse_auth(
+                &[
+                    "un".to_string(),
+                    "pw".to_string(),
+                    "h".to_string(),
+                    "t".to_string()
+                ],
+                &Url::parse("https://example.com/").unwrap()
+            ),
+            Ok(("un".to_string(), Some("pw".to_string()), "h".to_string()))
         )
     }
 }

--- a/src/scraper.rs
+++ b/src/scraper.rs
@@ -47,7 +47,12 @@ impl Scraper {
         let (tx, rx) = crossbeam::channel::unbounded();
 
         Scraper {
-            downloader: downloader::Downloader::new(args.tries, &args.user_agent, &args.auth),
+            downloader: downloader::Downloader::new(
+                args.tries,
+                &args.user_agent,
+                &args.auth,
+                &args.origin,
+            ),
             args,
             transmitter: tx,
             receiver: rx,

--- a/src/scraper.rs
+++ b/src/scraper.rs
@@ -47,7 +47,7 @@ impl Scraper {
         let (tx, rx) = crossbeam::channel::unbounded();
 
         Scraper {
-            downloader: downloader::Downloader::new(args.tries, &args.user_agent),
+            downloader: downloader::Downloader::new(args.tries, &args.user_agent, &args.auth),
             args,
             transmitter: tx,
             receiver: rx,
@@ -253,6 +253,7 @@ mod tests {
             verbose: true,
             include: Regex::new("jpg").unwrap(),
             exclude: Regex::new("png").unwrap(),
+            auth: Vec::new(),
             continue_on_error: true,
             dry_run: false,
         };
@@ -274,6 +275,7 @@ mod tests {
             verbose: true,
             include: Regex::new("jpg").unwrap(),
             exclude: Regex::new("png").unwrap(),
+            auth: Vec::new(),
             continue_on_error: true,
             dry_run: false,
         };

--- a/tests/auth.rs
+++ b/tests/auth.rs
@@ -1,0 +1,71 @@
+//! Tests for using --auth flags for suckit
+
+mod fixtures;
+
+use fixtures::get_file_count_with_pattern;
+use std::fs::read_dir;
+use std::process::Command;
+use std::process::Stdio;
+use std::sync::Once;
+
+const SUCKIT: &'static str = "target/debug/suckit";
+const ADDR: &'static str = "http://0.0.0.0:8000";
+static START: Once = Once::new();
+
+#[test]
+fn test_auth() {
+    // Spawn a single instance of a local http server usable by all tests in this module.
+    START.call_once(|| {
+        fixtures::spawn_local_http_server(true);
+    });
+
+    // Tests below are grouped together as they depend on the local_http_server above.
+    auth_different_host();
+    auth_valid();
+}
+
+// Shouldn't supply credentials to a non-matching host
+fn auth_different_host() {
+    let output_dir = "w4";
+    let mut cmd = Command::new(SUCKIT)
+        .args(&[
+            ADDR,
+            "-o",
+            "w4",
+            "-a",
+            "username password example.com",
+            "-j",
+            "16",
+        ])
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit())
+        .spawn()
+        .unwrap();
+
+    let status = cmd.wait().unwrap();
+    assert!(status.success());
+    let paths = read_dir(output_dir).unwrap();
+    // Only the initial invalid response file should be present
+    assert_eq!(paths.count(), 1);
+
+    std::fs::remove_dir_all(output_dir).unwrap();
+}
+
+// Should authenticate with credentials to host (defaulting to origin host)
+fn auth_valid() {
+    let output_dir = "w5";
+    let mut cmd = Command::new(SUCKIT)
+        .args(&[ADDR, "-o", "w5", "-a", "username password", "-j", "16"])
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit())
+        .spawn()
+        .unwrap();
+
+    let status = cmd.wait().unwrap();
+    assert!(status.success());
+    let paths = read_dir(output_dir).unwrap();
+    // Should load multiple paths, not just the invalid auth response
+    assert!(paths.count() > 1);
+
+    std::fs::remove_dir_all(output_dir).unwrap();
+}

--- a/tests/filters.rs
+++ b/tests/filters.rs
@@ -16,7 +16,7 @@ static START: Once = Once::new();
 fn test_include_exclude() {
     // Spawn a single instance of a local http server usable by all tests in this module.
     START.call_once(|| {
-        fixtures::spawn_local_http_server();
+        fixtures::spawn_local_http_server(false);
     });
 
     // Tests below are grouped together as they depend on the local_http_server above.


### PR DESCRIPTION
Progress on #87. Adds an initial setup for accepting comma-separated HTTP basic authentication information to create a mapping of URL hosts to username, password credentials.

This doesn't implement loading credentials from a file yet, but I wanted to check in on this approach before going any further. Any feedback is appreciated!