### PR TITLE
Use CARGO_BIN_EXE instead of hardcoded path for tests

### DIFF
--- a/tests/auth.rs
+++ b/tests/auth.rs
@@ -8,7 +8,6 @@ use std::process::Command;
 use std::process::Stdio;
 use std::sync::Once;
 
-const SUCKIT: &'static str = "target/debug/suckit";
 const ADDR: &'static str = "http://0.0.0.0:8000";
 static START: Once = Once::new();
 
@@ -27,7 +26,7 @@ fn test_auth() {
 // Shouldn't supply credentials to a non-matching host
 fn auth_different_host() {
     let output_dir = "w4";
-    let mut cmd = Command::new(SUCKIT)
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_suckit"))
         .args(&[
             ADDR,
             "-o",
@@ -54,7 +53,7 @@ fn auth_different_host() {
 // Should authenticate with credentials to host (defaulting to origin host)
 fn auth_valid() {
     let output_dir = "w5";
-    let mut cmd = Command::new(SUCKIT)
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_suckit"))
         .args(&[ADDR, "-o", "w5", "-a", "username password", "-j", "16"])
         .stdout(Stdio::inherit())
         .stderr(Stdio::inherit())

--- a/tests/filters.rs
+++ b/tests/filters.rs
@@ -8,7 +8,6 @@ use std::process::Command;
 use std::process::Stdio;
 use std::sync::Once;
 
-const SUCKIT: &'static str = "target/debug/suckit";
 const ADDR: &'static str = "http://0.0.0.0:8000";
 static START: Once = Once::new();
 
@@ -28,7 +27,7 @@ fn test_include_exclude() {
 // Test to use include flag for downloading pages only matching the given pattern.
 fn include_filter() {
     let output_dir = "w2";
-    let mut cmd = Command::new(SUCKIT)
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_suckit"))
         .args(&[ADDR, "-o", "w2", "-i", "mp[3-4]", "-j", "16"])
         .stdout(Stdio::inherit())
         .stderr(Stdio::inherit())
@@ -49,7 +48,7 @@ fn include_filter() {
 // Test demonstrating usage of multiple include patterns for downloading pages only matching the given pattern.
 fn include_multiple_filters() {
     let output_dir = "w1";
-    let mut cmd = Command::new(SUCKIT)
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_suckit"))
         .args(&[ADDR, "-o", output_dir, "-i", "(mp[3-4])|(txt)", "-j", "16"])
         .stdout(Stdio::inherit())
         .stderr(Stdio::inherit())
@@ -68,7 +67,7 @@ fn include_multiple_filters() {
 // Test to use exclude flag for excluding pages matching the given pattern.
 fn exclude_filter() {
     let output_dir = "w3";
-    let mut cmd = Command::new(SUCKIT)
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_suckit"))
         .args(&[ADDR, "-o", output_dir, "-e", "jpe?g", "-j", "16"])
         .stdout(Stdio::inherit())
         .stderr(Stdio::inherit())


### PR DESCRIPTION
`tests/auth.rs` and `tests/filters.rs` contains the following path constant for running the binary in tests.

```rust
const SUCKIT: &'static str = "target/debug/suckit";
```
This seems to work with `cargo test` since it builds the binary in `target/debug` directory.
But in the `cargo test --release` case, those tests fail since the binary is located in `target/release`

This pull request removes the hardcoded path constant and uses the `CARGO_BIN_EXE_<name>` environment variable for finding the correct binary path. (See https://github.com/rust-lang/cargo/pull/7697 for more information)