### PR TITLE
Remove hash fragment from scraped URLs

### DIFF
--- a/src/scraper.rs
+++ b/src/scraper.rs
@@ -105,8 +105,9 @@ impl Scraper {
             .into_iter()
             .filter(|candidate| Scraper::should_visit(candidate, &url))
             .for_each(|next_url| {
-                let next_full_url = url.join(&next_url).unwrap();
+                let mut next_full_url = url.join(&next_url).unwrap();
                 let path = url_helper::to_path(&next_full_url);
+                next_full_url.set_fragment(None);
 
                 if scraper.map_url_path(&next_full_url, path)
                     && (scraper.args.depth == INFINITE_DEPTH || depth < scraper.args.depth)

--- a/src/scraper.rs
+++ b/src/scraper.rs
@@ -105,14 +105,15 @@ impl Scraper {
             .into_iter()
             .filter(|candidate| Scraper::should_visit(candidate, &url))
             .for_each(|next_url| {
-                let mut next_full_url = url.join(&next_url).unwrap();
+                let next_full_url = url.join(&next_url).unwrap();
                 let path = url_helper::to_path(&next_full_url);
-                next_full_url.set_fragment(None);
 
                 if scraper.map_url_path(&next_full_url, path)
                     && (scraper.args.depth == INFINITE_DEPTH || depth < scraper.args.depth)
                 {
-                    Scraper::push(transmitter, next_full_url.clone(), depth + 1);
+                    let mut next_full_download_url = next_full_url.clone();
+                    next_full_download_url.set_fragment(None);
+                    Scraper::push(transmitter, next_full_download_url, depth + 1);
                 }
 
                 scraper.fix_domtree(next_url, &next_full_url);

--- a/src/url_helper.rs
+++ b/src/url_helper.rs
@@ -37,6 +37,13 @@ mod tests {
 
     #[test]
     fn url_to_path() {
+        let str = super::to_path(&Url::parse("https://lwn.net/Kernel/").unwrap());
+
+        assert_eq!(str, "lwn_net_Kernel");
+    }
+
+    #[test]
+    fn url_to_path_fragment() {
         let str = super::to_path(&Url::parse("https://lwn.net/Kernel/#fragment").unwrap());
 
         assert_eq!(str, "lwn_net_Kernel#fragment");

--- a/src/url_helper.rs
+++ b/src/url_helper.rs
@@ -13,6 +13,10 @@ pub fn encode(path: &str) -> String {
 
 ///Convert an Url to the corresponding path
 pub fn to_path(url: &Url) -> String {
+    let fragment = url.fragment();
+    let mut url = url.clone();
+    url.set_fragment(None);
+
     let url = url.as_str().split("://").collect::<Vec<&str>>()[1];
 
     let mut url = url.replace('/', "_").replace('.', "_");
@@ -21,7 +25,10 @@ pub fn to_path(url: &Url) -> String {
     }
     let url = url.trim_end_matches('_'); //Remaining '/'
 
-    url.to_string()
+    match fragment {
+        Some(fragment) => format!("{}#{}", url.to_string(), fragment),
+        None => url.to_string(),
+    }
 }
 
 #[cfg(test)]
@@ -30,9 +37,9 @@ mod tests {
 
     #[test]
     fn url_to_path() {
-        let str = super::to_path(&Url::parse("https://lwn.net/Kernel/").unwrap());
+        let str = super::to_path(&Url::parse("https://lwn.net/Kernel/#fragment").unwrap());
 
-        assert_eq!(str, "lwn_net_Kernel");
+        assert_eq!(str, "lwn_net_Kernel#fragment");
     }
 
     #[test]


### PR DESCRIPTION
Closes #99. Removes the fragment from scraped URLs because of the reasons mentioned in the issue.

I haven't added tests for this specifically since there's a lot of functionality in the method currently, but if it would be useful I can split off the URL/path handling lines into a separate method so that it's easier to test. I'm also not modifying the origin URL in `run` because it seems like that could be unexpected behavior. Let me know if I can make any changes, thanks!
