### PR TITLE
Update README about installation from AUR

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,14 @@ instructions on how to install Rust.
 
 * Now, run it from anywhere with the `suckit` command.
 
+### Arch Linux
+
+`suckit` can be installed from available [AUR packages](https://aur.archlinux.org/packages/?O=0&SeB=b&K=suckit&outdated=&SB=n&SO=a&PP=50&do_Search=Go) using an [AUR helper](https://wiki.archlinux.org/index.php/AUR_helpers). For example,
+
+```
+yay -S suckit
+```
+
 __Want to contribute ? Feel free to
 [open an issue](https://github.com/Skallwar/suckit/issues/new) or
 [submit a PR](https://github.com/Skallwar/suckit/compare) !__


### PR DESCRIPTION
Hey again,
I'm an [Arch Linux](https://aur.archlinux.org) package [maintainer](https://github.com/orhun/PKGBUILDs). I'm submitting this PR to let you know that I created the following packages for the installation of `suckit` on Arch Linux and other distributions that support installing packages from [AUR](https://wiki.archlinux.org/index.php/Arch_User_Repository):

* [suckit](https://aur.archlinux.org/packages/suckit/) (builds from source)
* [suckit-git](https://aur.archlinux.org/packages/suckit-git/) (VCS/development package)

I also updated README.md about installation from AUR. (7a1f7a6)

PS: I can also create a `-bin` package if you provide a pre-compiled x86_64 binary along with the release artifacts.