### PR TITLE
logger: fix panic! changes for Rust 2021

### DIFF
--- a/src/logger.rs
+++ b/src/logger.rs
@@ -39,7 +39,7 @@ impl Logger {
             "ERROR".red(),
             message
         );
-        panic!(message)
+        panic!("{}", message)
     }
 }
 


### PR DESCRIPTION
Prevent warning during build.

```
warning: panic message is not a string literal
  --> src/logger.rs:42:16
   |
42 |         panic!(message)
   |                ^^^^^^^
   |
   = note: `#[warn(non_fmt_panic)]` on by default
   = note: this is no longer accepted in Rust 2021
help: add a "{}" format string to Display the message
   |
42 |         panic!("{}", message)
   |                ^^^^^
help: or use std::panic::panic_any instead
   |
42 |         std::panic::panic_any(message)
   |         ^^^^^^^^^^^^^^^^^^^^^^

warning: 1 warning emitted
```