### PR TITLE
Fix querystring support

### DIFF
--- a/src/url_helper.rs
+++ b/src/url_helper.rs
@@ -22,7 +22,8 @@ pub fn to_path(url: &Url) -> String {
     });
     let mut parent = path
         .parent()
-        .map_or("", |filename| filename.to_str().unwrap()).to_string();
+        .map_or("", |filename| filename.to_str().unwrap())
+        .to_string();
 
     if url_path_and_query.ends_with("/") {
         filename = "index.html".to_string();
@@ -95,7 +96,12 @@ mod tests {
 
     #[test]
     fn url_to_path_querystrings() {
-        let str = super::to_path(&Url::parse("https://google.com/foobar/platform-redirect/?next=/configuration/releases/").unwrap());
+        let str = super::to_path(
+            &Url::parse(
+                "https://google.com/foobar/platform-redirect/?next=/configuration/releases/",
+            )
+            .unwrap(),
+        );
         assert_eq!(str, "google.com/foobar/platform-redirect/__querystring__next=/configuration/releases/index.html");
     }
 }

--- a/src/url_helper.rs
+++ b/src/url_helper.rs
@@ -9,28 +9,27 @@ const FILE_NAME_MAX_LENGTH: usize = 255;
 /// Convert an Url to the corresponding path
 pub fn to_path(url: &Url) -> String {
     let url_domain = url.host_str().unwrap();
-    let url_path = url.path();
-    let url_query = url.query();
 
-    let path = Path::new(url_path);
+    let mut url_path_and_query = url.path().to_string();
+    if let Some(query) = url.query() {
+        url_path_and_query.push_str("__querystring__");
+        url_path_and_query.push_str(query);
+    }
+
+    let path = Path::new(&url_path_and_query);
     let mut filename = path.file_name().map_or(String::from(""), |filename| {
         filename.to_str().unwrap().to_string()
     });
     let mut parent = path
         .parent()
-        .map_or("", |filename| filename.to_str().unwrap());
+        .map_or("", |filename| filename.to_str().unwrap()).to_string();
 
-    if url_path.ends_with("/") {
+    if url_path_and_query.ends_with("/") {
         filename = "index.html".to_string();
-        parent = url_path.trim_end_matches("/");
-    } else if path.extension().is_none() {
-        parent = url_path;
+        parent = url_path_and_query.trim_end_matches("/").to_string();
+    } else if Path::new(&filename).extension().is_none() {
+        parent = url_path_and_query.trim_end_matches("/").to_string();
         filename = "index_no_slash.html".to_string();
-    }
-
-    if url_query.is_some() {
-        filename.push('?');
-        filename.push_str(url_query.unwrap());
     }
 
     if filename.len() > FILE_NAME_MAX_LENGTH {
@@ -92,5 +91,11 @@ mod tests {
         let str = super::to_path(&Url::parse("https://lwn.net/Kernel/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.html").unwrap());
 
         assert_eq!(str, "lwn.net/Kernel/5ca82767de71fe8930587e82bb994903.html");
+    }
+
+    #[test]
+    fn url_to_path_querystrings() {
+        let str = super::to_path(&Url::parse("https://google.com/foobar/platform-redirect/?next=/configuration/releases/").unwrap());
+        assert_eq!(str, "google.com/foobar/platform-redirect/__querystring__next=/configuration/releases/index.html");
     }
 }


### PR DESCRIPTION
* While technically valid filenames, having ? in filenames means that the directory structure cannot be served by nginx as the resulting filenames cannot be addressed via URLs unless the ? is percent-encoded in every link.

* Query strings can contain trailing slashes. If that happens, suckit will attempt to create a directory, then create a same-named file, which fails

See #116