### PR TITLE
Change to png asciinema preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ A common use case could be the following:
 
 `suckit http://books.toscrape.com -j 8 -o /path/to/downloaded/pages/`
 
-<a href="https://asciinema.org/a/327889"><img alt="asciicast" src="https://asciinema.org/a/327889.png" width="500" /></a>
+<a href="https://asciinema.org/a/327889"><img alt="asciicast" src="https://asciinema.org/a/327889.png" width="500" align="middle" /></a>
 
 # Installation
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ A common use case could be the following:
 
 `suckit http://books.toscrape.com -j 8 -o /path/to/downloaded/pages/`
 
-[![asciicast](https://asciinema.org/a/327889.svg)](https://asciinema.org/a/327889)
+<a href="https://asciinema.org/a/327889"><img alt="asciicast" src="https://asciinema.org/a/327889.png" width="500" /></a>
 
 # Installation
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,9 @@ A common use case could be the following:
 
 `suckit http://books.toscrape.com -j 8 -o /path/to/downloaded/pages/`
 
-<a href="https://asciinema.org/a/327889"><img alt="asciicast" src="https://asciinema.org/a/327889.png" width="500" align="middle" /></a>
+<p align="center">
+<a href="https://asciinema.org/a/327889"><img alt="asciicast" src="https://asciinema.org/a/327889.png" width="500" /></a>
+</p>
 
 # Installation
 


### PR DESCRIPTION
The SVG version locks up the tab for me in Firefox, and I am on a fairly beefy machine. The preview image is also very large, so downscaling it a bit may be preferrable for saving vertical space + help with sharpness on retina