### PR TITLE
Filter links before downloading / adding to the queue

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -86,6 +86,24 @@ pub struct Args {
     )]
     pub user_agent: String,
 
+    /// Regex filter to limit visiting pages to only matched ones
+    #[structopt(
+    long,
+    default_value = ".*",
+    parse(try_from_str = parse_regex),
+    help = "Regex filter to limit to only visiting pages that match this expression"
+    )]
+    pub include_visit: Regex,
+
+    /// Regex filter to limit visiting pages to only matched ones
+    #[structopt(
+    long,
+    default_value = "$^",
+    parse(try_from_str = parse_regex),
+    help = "Regex filter to exclude visiting pages that match this expression"
+    )]
+    pub exclude_visit: Regex,
+
     /// Regex filter to limit saving pages to only matched ones
     #[structopt(
     short,
@@ -94,7 +112,7 @@ pub struct Args {
     parse(try_from_str = parse_regex),
     help = "Regex filter to limit to only saving pages that match this expression"
     )]
-    pub include: Regex,
+    pub include_download: Regex,
 
     /// Regex filter to limit saving pages to only matched ones
     #[structopt(
@@ -104,7 +122,14 @@ pub struct Args {
     parse(try_from_str = parse_regex),
     help = "Regex filter to exclude saving pages that match this expression"
     )]
-    pub exclude: Regex,
+    pub exclude_download: Regex,
+
+    /// If set, set the visit filter to the values of the download filter
+    #[structopt(
+        long,
+        help = "Use the dowload filter in/exclude regexes for visiting as well"
+    )]
+    pub visit_filter_is_download_filter: bool,
 
     /// HTTP basic authentication credentials
     #[structopt(

--- a/src/scraper.rs
+++ b/src/scraper.rs
@@ -250,9 +250,9 @@ impl Scraper {
                     // it is pushed into the channel unconditionally.
                     // we want to process its links, but maybe not download it.
                     // all other links are filtered before they are added to the channel.
-                    let filter_rules_match = (depth > 0
+                    let filter_rules_match = depth > 0
                         || (!scraper.args.exclude.is_match(url.as_str())
-                            && scraper.args.include.is_match(url.as_str())));
+                            && scraper.args.include.is_match(url.as_str()));
                     if !scraper.args.dry_run && filter_rules_match {
                         match response.filename {
                             Some(filename) => {

--- a/src/scraper.rs
+++ b/src/scraper.rs
@@ -30,7 +30,7 @@ static MAX_EMPTY_RECEIVES: usize = 10;
 static INFINITE_DEPTH: i32 = -1;
 
 /// Sleep duration on empty recv()
-static SLEEP_MILLIS: u64 = 100;
+static SLEEP_MILLIS: u64 = 500;
 static SLEEP_DURATION: time::Duration = time::Duration::from_millis(SLEEP_MILLIS);
 
 /// Producer and Consumer data structure. Handles the incoming requests and

--- a/tests/filters.rs
+++ b/tests/filters.rs
@@ -28,6 +28,8 @@ fn test_include_exclude() {
 // Test to use include flag for downloading pages only matching the given pattern.
 fn download_include_filter() {
     let output_dir = "w2";
+    let _ = std::fs::remove_dir_all(output_dir);
+
     let files_dir = format!("{}/{}/", output_dir, IP);
     let mut cmd = Command::new(env!("CARGO_BIN_EXE_suckit"))
         .args(&[
@@ -59,6 +61,8 @@ fn download_include_filter() {
 // Test demonstrating usage of multiple include patterns for downloading pages only matching the given pattern.
 fn download_include_multiple_filters() {
     let output_dir = "w1";
+    let _ = std::fs::remove_dir_all(output_dir);
+
     let files_dir = format!("{}/{}/", output_dir, IP);
     let mut cmd = Command::new(env!("CARGO_BIN_EXE_suckit"))
         .args(&[
@@ -87,6 +91,8 @@ fn download_include_multiple_filters() {
 // Test to use exclude flag for excluding pages matching the given pattern.
 fn download_exclude_filter() {
     let output_dir = "w3";
+    let _ = std::fs::remove_dir_all(output_dir);
+
     let files_dir = format!("{}/{}/", output_dir, IP);
     let mut cmd = Command::new(env!("CARGO_BIN_EXE_suckit"))
         .args(&[

--- a/tests/filters.rs
+++ b/tests/filters.rs
@@ -23,6 +23,108 @@ fn test_include_exclude() {
     download_include_filter();
     download_include_multiple_filters();
     download_exclude_filter();
+
+    visit_include_filter();
+    visit_include_multiple_filters();
+    visit_exclude_filter();
+}
+
+// Test to use include flag for visiting pages only matching the given pattern.
+fn visit_include_filter() {
+    let output_dir = "w2";
+    let _ = std::fs::remove_dir_all(output_dir);
+
+    let files_dir = format!("{}/{}/", output_dir, IP);
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_suckit"))
+        .args(&[
+            fixtures::HTTP_ADDR,
+            "-o",
+            output_dir,
+            "--include-visit",
+            "mp[3-4]",
+            "-j",
+            "16",
+        ])
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit())
+        .spawn()
+        .unwrap();
+
+    let status = cmd.wait().unwrap();
+    assert!(status.success());
+    let paths = read_dir(&files_dir).unwrap();
+
+    assert_eq!(
+        paths.count() - 1, // minus one because of index.html which is downloaded unconditionally
+        get_file_count_with_pattern(".mp3", &files_dir).unwrap()
+    );
+
+    std::fs::remove_dir_all(output_dir).unwrap();
+}
+
+// Test demonstrating usage of multiple include patterns for visiting pages only matching the given pattern.
+fn visit_include_multiple_filters() {
+    let output_dir = "w1";
+    let _ = std::fs::remove_dir_all(output_dir);
+
+    let files_dir = format!("{}/{}/", output_dir, IP);
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_suckit"))
+        .args(&[
+            fixtures::HTTP_ADDR,
+            "-o",
+            output_dir,
+            "--include-visit",
+            "(mp[3-4])|(txt)",
+            "-j",
+            "16",
+        ])
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit())
+        .spawn()
+        .unwrap();
+    let status = cmd.wait().unwrap();
+    assert!(status.success());
+    let paths = read_dir(&files_dir).unwrap();
+    let mp3_count = get_file_count_with_pattern(".mp3", &files_dir).unwrap();
+    let txt_count = get_file_count_with_pattern(".txt", &files_dir).unwrap();
+    assert_eq!(
+        paths.count() - 1, // minus one because of index.html which is downloaded unconditionally
+        mp3_count + txt_count
+    );
+
+    std::fs::remove_dir_all(output_dir).unwrap();
+}
+
+// Test to use exclude flag for excluding pages matching the given pattern.
+fn visit_exclude_filter() {
+    let output_dir = "w3";
+    let _ = std::fs::remove_dir_all(output_dir);
+
+    let files_dir = format!("{}/{}/", output_dir, IP);
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_suckit"))
+        .args(&[
+            fixtures::HTTP_ADDR,
+            "-o",
+            output_dir,
+            "--exclude-visit",
+            "jpe?g",
+            "-j",
+            "16",
+        ])
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit())
+        .spawn()
+        .unwrap();
+
+    let status = cmd.wait().unwrap();
+    assert!(status.success());
+    let paths = read_dir(&files_dir).unwrap();
+    let mp3_count = get_file_count_with_pattern(".mp3", &files_dir).unwrap();
+    let txt_count = get_file_count_with_pattern(".txt", &files_dir).unwrap();
+    let index_file = 1;
+    assert_eq!(paths.count(), mp3_count + txt_count + index_file);
+
+    std::fs::remove_dir_all(output_dir).unwrap();
 }
 
 // Test to use include flag for downloading pages only matching the given pattern.

--- a/tests/filters.rs
+++ b/tests/filters.rs
@@ -20,13 +20,13 @@ fn test_include_exclude() {
     });
 
     // Tests below are grouped together as they depend on the local_http_server above.
-    include_filter();
-    include_multiple_filters();
-    exclude_filter();
+    download_include_filter();
+    download_include_multiple_filters();
+    download_exclude_filter();
 }
 
 // Test to use include flag for downloading pages only matching the given pattern.
-fn include_filter() {
+fn download_include_filter() {
     let output_dir = "w2";
     let files_dir = format!("{}/{}/", output_dir, IP);
     let mut cmd = Command::new(env!("CARGO_BIN_EXE_suckit"))
@@ -57,7 +57,7 @@ fn include_filter() {
 }
 
 // Test demonstrating usage of multiple include patterns for downloading pages only matching the given pattern.
-fn include_multiple_filters() {
+fn download_include_multiple_filters() {
     let output_dir = "w1";
     let files_dir = format!("{}/{}/", output_dir, IP);
     let mut cmd = Command::new(env!("CARGO_BIN_EXE_suckit"))
@@ -85,7 +85,7 @@ fn include_multiple_filters() {
 }
 
 // Test to use exclude flag for excluding pages matching the given pattern.
-fn exclude_filter() {
+fn download_exclude_filter() {
     let output_dir = "w3";
     let files_dir = format!("{}/{}/", output_dir, IP);
     let mut cmd = Command::new(env!("CARGO_BIN_EXE_suckit"))


### PR DESCRIPTION
This commit speeds up scraping for scenarios where pages have a high branch factor, that is many links and a majority of these links is excluded by the --exclude / --include rules.
This also improves memory usage in these scenarios since the links are not stored.
Also the network traffic is reduced by not downloading these links in the first place.