### PR TITLE
Fix paths of symlink warning logging call

### DIFF
--- a/src/disk.rs
+++ b/src/disk.rs
@@ -42,8 +42,8 @@ pub fn symlink(source: &str, destination: &str, path: &Option<PathBuf>) {
     if symlink_auto(source, &destination).is_err() {
         warn!(
             "{} is already present, coulnd't create a symlink to {}",
-            destination.display(),
             source,
+            destination.display(),
         );
     }
 }


### PR DESCRIPTION
I think the paths in the logging message are swapped, this commit fixes that.