### PR TITLE
Include fragments on html files

### DIFF
--- a/src/url_helper.rs
+++ b/src/url_helper.rs
@@ -40,8 +40,7 @@ pub fn to_path(url: &Url, with_fragment: bool) -> String {
 
     match (url.fragment(), with_fragment) {
         (Some(fragment), true) => format!("{}{}/{}#{}", url_domain, parent, filename, fragment),
-        (None, true) => format!("{}{}/{}", url_domain, parent, filename),
-        (_, false) => format!("{}{}/{}", url_domain, parent, filename),
+        (_, _) => format!("{}{}/{}", url_domain, parent, filename),
     }
 }
 


### PR DESCRIPTION
My use case requires `suckit` to maintain fragments within paths, for example, `href="#sub-title"` becomes `href="index.html#sub-title"`.
I re-enabled the fragment part only for the downloaded Html files. The visited hash map only records the Url's path without storing the fragment.

One downside of the PR implementation is the introduction of an additional argument.

```rust
pub fn to_path(url: &Url, with_fragment: bool) -> String { ... }
```

I'm making this PR in case anybody needs the feature. From my point of view, it is essential. 

Have a nice day. This is related to #99 and #100 