### PR TITLE
Limit folder names length and avoid panic on malformed URLs

### DIFF
--- a/src/scraper.rs
+++ b/src/scraper.rs
@@ -192,7 +192,10 @@ impl Scraper {
 
                 let next_full_url = match url.join(url_to_parse.as_str()) {
                     Ok(url) => url,
-                    Err(e) => panic!("Failed to parse url: {} | Error: {}", next_url, e),
+                    Err(e) => {
+                        warn!("Failed to parse url: {} | Error: {}", next_url, e);
+                        return;
+                    },
                 };
 
                 let path = url_helper::to_path(&next_full_url, true);

--- a/src/url_helper.rs
+++ b/src/url_helper.rs
@@ -1,6 +1,7 @@
 use std::path::Path;
 
 use md5;
+use std::borrow::Cow;
 use url::Url;
 
 ///Max file name size supported by the file system
@@ -24,6 +25,19 @@ pub fn to_path(url: &Url, with_fragment: bool) -> String {
         .parent()
         .map_or("", |filename| filename.to_str().unwrap())
         .to_string();
+
+    // Ensure the folder names are not too long
+    parent = parent
+        .split('/')
+        .map(|str| {
+            if str.len() > FILE_NAME_MAX_LENGTH {
+                Cow::Owned(format!("{:x}", md5::compute(str)))
+            } else {
+                Cow::Borrowed(str)
+            }
+        })
+        .collect::<Vec<Cow<str>>>()
+        .join("/");
 
     if url_path_and_query.ends_with('/') {
         filename = "index.html".to_string();


### PR DESCRIPTION
Two little fixes:
- avoid panic when encountering malformed URLs
- limit folder names length by taking the md5 digest when the length exceeds a set threshold (again, avoiding panics)

Fixes #239
